### PR TITLE
Improved game support on VT-52 terminals (MSX)

### DIFF
--- a/source/game.mod
+++ b/source/game.mod
@@ -194,6 +194,9 @@ PROCEDURE DrawBuilding(VAR color:STRINGSEQ;x,h,w:CARDINAL);
 VAR i,j,count:CARDINAL;
     line:ARRAY [0..15] OF CHAR;
 BEGIN
+  (* avoid to startup with invisible buildings if there isn't revere
+     video on current terminal and block is a blank space *)
+  IF (SEQ[REVERSE]='') AND (block=' ') THEN block:=377C END;
   WRITE(color);
   FILL(ADR(line),15,ORD(block));
   line[w]:=0C;

--- a/source/main.mod
+++ b/source/main.mod
@@ -33,54 +33,77 @@ BEGIN
 
   WRITE(SEQ[YELLOW]);
 
-  CursorXY(x+46,y+0);
-  WRITE(SEQ[REVERSE],'     ',SEQ[PLAIN],'    ',SEQ[REVERSE],'  ',SEQ[PLAIN],'    ',
-  SEQ[REVERSE],'    ');
+  IF SEQ[REVERSE]='' THEN
+    CursorXY(x+46,y+0);
+    WRITE('/////    //    ////');
 
-  CursorXY(x+46,y+1);
-  WRITE(SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',
-  SEQ[REVERSE],'    ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',
-  SEQ[REVERSE],'  ');
+    CursorXY(x+46,y+1);
+    WRITE('//  //  ////  //  //');
 
-  CursorXY(x+46,y+2);
-  WRITE(SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],' ',
-  SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],' ',SEQ[REVERSE],'  ');
+    CursorXY(x+46,y+2);
+    WRITE('//  // //  // //');
 
-  CursorXY(x,y+3);
-  WRITELN(SEQ[PLAIN],' ',SEQ[REVERSE],'    ',SEQ[PLAIN],'   ',SEQ[REVERSE],'    ',
-  SEQ[PLAIN],'  ',SEQ[REVERSE],'     ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',
-  SEQ[PLAIN],' ',SEQ[REVERSE],'  ',SEQ[PLAIN],'    ',SEQ[REVERSE],'  ',SEQ[PLAIN],
-  '     ',SEQ[REVERSE],'    ',SEQ[PLAIN],'     ',SEQ[REVERSE],'     ',SEQ[PLAIN],
-  '  ',SEQ[REVERSE],'      ',SEQ[PLAIN],'  ',SEQ[REVERSE],'    ');
+    CursorXY(x,y+3);
+    WRITE(' ////   ////  /////  // //    //     ////     /////  //////  ////');
 
-  CursorXY(x,y+4);
-  WRITELN(SEQ[REVERSE],'  ',SEQ[PLAIN],'     ',SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',
-  SEQ[REVERSE],'  ',SEQ[PLAIN],' ',SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',SEQ[REVERSE],
-  '  ',SEQ[PLAIN],' ',SEQ[REVERSE],'  ',SEQ[PLAIN],' ',SEQ[REVERSE],'  ',SEQ[PLAIN],
-  '    ',SEQ[REVERSE],'  ',SEQ[PLAIN],'    ',SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',
-  SEQ[REVERSE],'  ',SEQ[PLAIN],'    ',SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',
-  SEQ[REVERSE],'  ',SEQ[PLAIN],' ',SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',SEQ[REVERSE],
-  '  ',SEQ[PLAIN],'     ',SEQ[REVERSE],'  ');
+    CursorXY(x,y+4);
+    WRITE('//     //  // //  // // //    //    //  //    //  // //  //     //');
 
-  CursorXY(x,y+5);
-  WRITE(SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],' ',
-  SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],' ',
-  SEQ[REVERSE],'     ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],' ',
-  SEQ[REVERSE],'  ',SEQ[PLAIN],'    '
-  ,SEQ[REVERSE],'  ',SEQ[PLAIN],'    ',
-  SEQ[REVERSE],'      ',SEQ[PLAIN],' ',SEQ[PLAIN] ,'  ',SEQ[PLAIN],' ',
-  SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],' ', SEQ[REVERSE],
-  '  ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],' ',SEQ[REVERSE],'  ',SEQ[PLAIN],
-  '  ',SEQ[REVERSE],'  ');
+    CursorXY(x,y+5);
+    WRITE('//  // //  // /////  // //    //    //////    //  // //  // //  //');
 
-  CursorXY(x,y+6);
-  WRITE(SEQ[PLAIN],' ',SEQ[REVERSE],'    ',SEQ[PLAIN],'   ',SEQ[REVERSE],'    ',
-  SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],' ',
-  SEQ[REVERSE],'  ',SEQ[PLAIN],' ',SEQ[REVERSE],'     ',SEQ[PLAIN],' ',SEQ[REVERSE],
-  '     ',SEQ[PLAIN],' ',SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',
-  SEQ[PLAIN],' ',SEQ[REVERSE],'  ',SEQ[PLAIN],' ',SEQ[REVERSE],'     ',SEQ[PLAIN],
-  '  ',SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',
-  SEQ[REVERSE],'    ',SEQ[PLAIN]);
+    CursorXY(x,y+6);
+    WRITE(' ////   ////  //  // // ///// ///// //  // // /////  //  //  ////');
+  ELSE
+    CursorXY(x+46,y+0);
+    WRITE(SEQ[REVERSE],'     ',SEQ[PLAIN],'    ',SEQ[REVERSE],'  ',SEQ[PLAIN],'    ',
+    SEQ[REVERSE],'    ');
+
+    CursorXY(x+46,y+1);
+    WRITE(SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',
+    SEQ[REVERSE],'    ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',
+    SEQ[REVERSE],'  ');
+
+    CursorXY(x+46,y+2);
+    WRITE(SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],' ',
+    SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],' ',SEQ[REVERSE],'  ');
+
+    CursorXY(x,y+3);
+    WRITE(SEQ[PLAIN],' ',SEQ[REVERSE],'    ',SEQ[PLAIN],'   ',SEQ[REVERSE],'    ',
+    SEQ[PLAIN],'  ',SEQ[REVERSE],'     ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',
+    SEQ[PLAIN],' ',SEQ[REVERSE],'  ',SEQ[PLAIN],'    ',SEQ[REVERSE],'  ',SEQ[PLAIN],
+    '     ',SEQ[REVERSE],'    ',SEQ[PLAIN],'     ',SEQ[REVERSE],'     ',SEQ[PLAIN],
+    '  ',SEQ[REVERSE],'      ',SEQ[PLAIN],'  ',SEQ[REVERSE],'    ');
+
+    CursorXY(x,y+4);
+    WRITE(SEQ[REVERSE],'  ',SEQ[PLAIN],'     ',SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',
+    SEQ[REVERSE],'  ',SEQ[PLAIN],' ',SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',SEQ[REVERSE],
+    '  ',SEQ[PLAIN],' ',SEQ[REVERSE],'  ',SEQ[PLAIN],' ',SEQ[REVERSE],'  ',SEQ[PLAIN],
+    '    ',SEQ[REVERSE],'  ',SEQ[PLAIN],'    ',SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',
+    SEQ[REVERSE],'  ',SEQ[PLAIN],'    ',SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',
+    SEQ[REVERSE],'  ',SEQ[PLAIN],' ',SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',SEQ[REVERSE],
+    '  ',SEQ[PLAIN],'     ',SEQ[REVERSE],'  ');
+
+    CursorXY(x,y+5);
+    WRITE(SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],' ',
+    SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],' ',
+    SEQ[REVERSE],'     ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],' ',
+    SEQ[REVERSE],'  ',SEQ[PLAIN],'    '
+    ,SEQ[REVERSE],'  ',SEQ[PLAIN],'    ',
+    SEQ[REVERSE],'      ',SEQ[PLAIN],' ',SEQ[PLAIN] ,'  ',SEQ[PLAIN],' ',
+    SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],' ', SEQ[REVERSE],
+    '  ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],' ',SEQ[REVERSE],'  ',SEQ[PLAIN],
+    '  ',SEQ[REVERSE],'  ');
+
+    CursorXY(x,y+6);
+    WRITE(SEQ[PLAIN],' ',SEQ[REVERSE],'    ',SEQ[PLAIN],'   ',SEQ[REVERSE],'    ',
+    SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],' ',
+    SEQ[REVERSE],'  ',SEQ[PLAIN],' ',SEQ[REVERSE],'     ',SEQ[PLAIN],' ',SEQ[REVERSE],
+    '     ',SEQ[PLAIN],' ',SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',
+    SEQ[PLAIN],' ',SEQ[REVERSE],'  ',SEQ[PLAIN],' ',SEQ[REVERSE],'     ',SEQ[PLAIN],
+    '  ',SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',SEQ[REVERSE],'  ',SEQ[PLAIN],'  ',
+    SEQ[REVERSE],'    ',SEQ[PLAIN]);
+  END;
 
   WRITE(SEQ[CYAN]);
   CursorXY(x+1,y+0); WRITE('CP/M-80 & Turbo Modula-2 version (C) 2015');

--- a/source/xterm.mod
+++ b/source/xterm.mod
@@ -256,8 +256,8 @@ BEGIN
   SEQ[INSLINE]:='*L'; SEQ[INSLINE][0]:=33C;
   SEQ[DELLINE]:='*M'; SEQ[DELLINE][0]:=33C;
   SEQ[BEEP]:='x'; SEQ[BEEP][0]:=7C;
-  SEQ[CURSORON]:='';
-  SEQ[CURSOROFF]:='';
+  SEQ[CURSORON]:='*y5'; SEQ[CURSORON][0]:=33C;
+  SEQ[CURSOROFF]:='*x5'; SEQ[CURSOROFF][0]:=33C;
   SEQ[TERMRESET]:='';
 END InitVT52;
 
@@ -354,13 +354,22 @@ VAR i,j:CARDINAL;
     s:ARRAY[0..79] OF CHAR;
 BEGIN
   s:='                                                                                ';
+  (* if there isn't reverse video option on the current terminal,
+     (re)populates 's' array with ASCII 255. *)
+  IF SEQ[REVERSE]='' THEN
+    FOR i:=0 TO 79 DO
+       s[i]:=377C;
+    END;
+  END;
   s[x2-x1+1]:=0C;
   WRITE(SEQ[REVERSE]);
   IF v THEN
     FOR i:=1 TO 2 DO
       FOR j:=y1 TO y2 DO
         IF i=1 THEN CursorXY(x1,j) ELSE CursorXY(x2,j) END;
-        WRITE(' ');
+        (* if there isn't reverse video option on the current terminal,
+           uses ASCII 255 char, uses space *)
+        IF SEQ[REVERSE]='' THEN WRITE(377C) ELSE WRITE(' ') END;
       END;
     END;
   END;


### PR DESCRIPTION
There aren't color nor even reverse video support on VT-52 terminal, so the game doesn't properly work on it. These changes fix both title and border display on main screen and avoid the use of spaces ("` `") to draw the buildings.